### PR TITLE
gather additional objects relevant to disconnected environments

### DIFF
--- a/scripts/rhm_metering_dump.sh
+++ b/scripts/rhm_metering_dump.sh
@@ -103,42 +103,42 @@ testconnection
 checkOCCliVersion
 checkOCServerVersion
 
-displayheading "Getting openshift server and client version"
+displayHeading "Getting openshift server and client version"
 oc version
 
-displayheading "Verifying if ${NAMESPACE} namespace already exists"
+displayHeading "Verifying if ${NAMESPACE} namespace already exists"
 checkrhmoperator
 
-displayheading "Status of all pods in ${NAMESPACE}"
+displayHeading "Status of all pods in ${NAMESPACE}"
 oc get pods -n openshift-redhat-marketplace 
 
-displayheading 'Status of MeterReports'
+displayHeading 'Status of MeterReports'
 oc get meterreports -A
 
-displayheading 'Status of MeterDefinitions'
+displayHeading 'Status of MeterDefinitions'
 oc get meterdefinitions -A
 
 for POD in $(oc get pods -n $NAMESPACE --output json | jq '.items[] | .metadata.name' | sed 's/"//g')
 do
   if [[ "${POD}" == "rhm-metric-state"* ]]; then
-    displayheading "Describing pod ${POD}"
+    displayHeading "Describing pod ${POD}"
     oc describe pod "${POD}" -n ${NAMESPACE}
-    displayheading "Logs from the pod ${POD}"
+    displayHeading "Logs from the pod ${POD}"
     oc logs "${POD}" -n ${NAMESPACE} --all-containers --tail=500
   elif [[ "${POD}" == "rhm-remoteresources3-controller"* ]]; then
-    displayheading "Describing pod ${POD}"
+    displayHeading "Describing pod ${POD}"
     oc describe pod "${POD}" -n ${NAMESPACE}
-    displayheading "Logs from the pod ${POD}"
+    displayHeading "Logs from the pod ${POD}"
     oc logs "${POD}" -n ${NAMESPACE} --all-containers --tail=500
   elif [[ "${POD}" == "meter-report-$(date '+%Y-%m-%d')"* ]]; then
-    displayheading "Describing pod ${POD}"
+    displayHeading "Describing pod ${POD}"
     oc describe pod "${POD}" -n ${NAMESPACE}
-    displayheading "Logs from the pod ${POD}"
+    displayHeading "Logs from the pod ${POD}"
     oc logs "${POD}" -n ${NAMESPACE} --all-containers --tail=500
   elif [[ "${POD}" == "meter-report-$(date +%Y-%m-%d -d "yesterday")"* ]]; then
-    displayheading "Describing pod ${POD}"
+    displayHeading "Describing pod ${POD}"
     oc describe pod "${POD}" -n ${NAMESPACE}
-    displayheading "Logs from the pod ${POD}"
+    displayHeading "Logs from the pod ${POD}"
     oc logs "${POD}" -n ${NAMESPACE} --all-containers --tail=500
   fi;
 done

--- a/scripts/rhm_operator_dump.sh
+++ b/scripts/rhm_operator_dump.sh
@@ -88,6 +88,9 @@ testConnection
 displayHeading 'Checking jq version'
 jq --version 2> /dev/null || errorExit "[ERROR] Pre-requisite cli 'jq' is not installed\n"
 
+displayHeading 'Checking yq version'
+yq --version 2> /dev/null || errorExit "[ERROR] Pre-requisite cli 'yq' is not installed\n"
+
 checkOCCliVersion
 checkOCServerVersion
 
@@ -140,3 +143,17 @@ oc describe remoteresources3 parent  -n $NAMESPACE
 displayHeading "Describing Remoteresources3 child"
 oc describe remoteresources3 child  -n $NAMESPACE
 
+displayHeading "Getting MarketplaceConfig in namespace $NAMESPACE"
+oc get marketplaceconfig -n $NAMESPACE -o=yaml
+
+displayHeading "Getting Services in namespace $NAMESPACE"
+oc get service -n $NAMESPACE
+
+displayHeading "Getting Routes in namespace $NAMESPACE"
+oc get route -n $NAMESPACE
+
+displayHeading "Getting datactl configuration"
+FILE=$HOME/.datactl/config
+if [ -f "$FILE" ]; then
+    yq eval 'del(.upload-api.pull-secret-data)' $FILE
+fi

--- a/scripts/rhm_operator_dump.sh
+++ b/scripts/rhm_operator_dump.sh
@@ -88,9 +88,6 @@ testConnection
 displayHeading 'Checking jq version'
 jq --version 2> /dev/null || errorExit "[ERROR] Pre-requisite cli 'jq' is not installed\n"
 
-displayHeading 'Checking yq version'
-yq --version 2> /dev/null || errorExit "[ERROR] Pre-requisite cli 'yq' is not installed\n"
-
 checkOCCliVersion
 checkOCServerVersion
 
@@ -155,5 +152,5 @@ oc get route -n $NAMESPACE
 displayHeading "Getting datactl configuration"
 FILE=$HOME/.datactl/config
 if [ -f "$FILE" ]; then
-    yq eval 'del(.upload-api.pull-secret-data)' $FILE
+    sed -e '/^  pull-secret-data:/ d' -e '/^  token-data:/ d' $FILE
 fi


### PR DESCRIPTION
- Fix displayheading camel case for rhm_metering_dump
- Support gathering of additional objects relevant to disconnected environments
  - MarketplaceConfig, Services, Routes
  - datactl config yaml file
    - pull-secret  & sa token removed from output
    - use sed, instead of requiring yq